### PR TITLE
UIP-1349 - Export stringLiteral and getSpan

### DIFF
--- a/lib/transformer_utils.dart
+++ b/lib/transformer_utils.dart
@@ -15,10 +15,7 @@
 library transformer_utils;
 
 export 'package:transformer_utils/src/analyzer_helpers.dart'
-    show
-        copyClassMember,
-        getDeclarationsAnnotatedBy,
-        instantiateAnnotation;
+    show copyClassMember, getDeclarationsAnnotatedBy, instantiateAnnotation;
 export 'package:transformer_utils/src/barback_utils.dart'
     show assetIdToPackageUri, getSpanForNode;
 export 'package:transformer_utils/src/jet_brains_friendly_logger.dart'

--- a/lib/transformer_utils.dart
+++ b/lib/transformer_utils.dart
@@ -18,12 +18,12 @@ export 'package:transformer_utils/src/analyzer_helpers.dart'
     show
         copyClassMember,
         getDeclarationsAnnotatedBy,
-        getLiteralValue,
         instantiateAnnotation;
 export 'package:transformer_utils/src/barback_utils.dart'
     show assetIdToPackageUri, getSpanForNode;
 export 'package:transformer_utils/src/jet_brains_friendly_logger.dart'
     show JetBrainsFriendlyLogger;
 export 'package:transformer_utils/src/node_with_meta.dart' show NodeWithMeta;
+export 'package:transformer_utils/src/text_util.dart' show stringLiteral;
 export 'package:transformer_utils/src/transformed_source_file.dart'
-    show TransformedSourceFile;
+    show TransformedSourceFile, getSpan;


### PR DESCRIPTION
## Ultimate Problem
`stringLiteral` and `getSpan` were not being exported by `transformer_utils.dart`. In order to use them you have to import files from within `lib/src`.

## Solution
- Export `text_util.dart` and show `stringLiteral`.
- Include `getSpan` in what to show from `transformed_source_file.dart`.

## Also Fixed
- Removed `getLiteralValue` from what is shown from `analyzer_helpers.dart`
  - `getLiteralValue` does not exist.

## Testing Suggestions
- Verify `stringLiteral` and `getSpan` are being exported from `transformer_utils.dart`.

FYA: @greglittlefield-wf @evanweible-wf 