### PR TITLE
UIP-1906 Widen version constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 homepage: https://github.com/Workiva/dart_transformer_utils
 dependencies:
-  analyzer: "^0.27.0"
+  analyzer: ">=0.27.0 <0.30.0"
   barback: "^0.15.0"
   path: "^1.3.0"
   source_span: "^1.2.0"

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,12 @@
+project: dart
+language: dart
+
+# dart 1.19.1, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.4
+runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:74173
+
+script:
+  - pub get
+
+artifacts:
+  build:
+    - ./pubspec.lock


### PR DESCRIPTION
## Ultimate Problem
`analyzer` was being bound to <0.28.0, we should widen that constraint to allow <0.30.0.

## Solution
- Widen the `analyzer` version constraint

## Testing Suggestions
- Verify tests still pass

## Possible Areas of Regression
- None expected

---
FYA: @greglittlefield-wf @evanweible-wf 