### PR TITLE
UIP-1958 Release dart_transformer_utils 0.1.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: transformer_utils
-version: 0.1.2
+version: 0.1.3
 description: Utilities relating to code generation, Dart analyzer, logging, etc. for use in Pub transformers.
 authors:
   - Workiva UI Platform Team <uip@workiva.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 homepage: https://github.com/Workiva/dart_transformer_utils
 dependencies:
-  analyzer: ">=0.27.0 <0.30.0"
+  analyzer: ">=0.27.0 <0.31.0"
   barback: "^0.15.0"
   path: "^1.3.0"
   source_span: "^1.2.0"


### PR DESCRIPTION
__This patch release includes the following changes:__

## Dependency Updates
- https://github.com/Workiva/dart_transformer_utils/pull/13/commits/15c6e6f58682363e1bb59819b52dabd09bc4883d analyzer `>=0.27.0 <0.31.0` (was `>=0.27.0 <0.30.0`) ([UIP-2288](https://jira.atl.workiva.net/browse/UIP-2288))