### PR TITLE
Update analyzer version range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 homepage: https://github.com/Workiva/dart_transformer_utils
 dependencies:
-  analyzer: ">=0.27.0 <=0.31.0"
-  barback: ">=0.15.2 <=0.15.2+14"
+  analyzer: ">=0.27.0 <0.33.0"
+  barback: ">=0.15.2 <0.16.0"
   path: "^1.3.0"
   source_span: "^1.2.0"
 


### PR DESCRIPTION
Allow newer versions of `analyzer` that will resolve when running `pub get` on Dart 2.

@Workiva/app-frameworks 