### PR TITLE
Use dart2_constant for HtmlEscapeMode constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.dart_tool
 /.idea
 /.packages
 /.pub

--- a/lib/src/transformed_source_file.dart
+++ b/lib/src/transformed_source_file.dart
@@ -17,6 +17,7 @@ library transformer_utils.src.transformed_source_file;
 import 'dart:convert';
 
 import 'package:analyzer/analyzer.dart';
+import 'package:dart2_constant/convert.dart' as convert_constant;
 import 'package:source_span/source_span.dart';
 
 /// A record used internally by [TransformedSourceFile] that represents the
@@ -108,8 +109,10 @@ class TransformedSourceFile {
   }
 
   String getHtmlDiff() {
-    const HtmlEscape elementEscaper = const HtmlEscape(HtmlEscapeMode.ELEMENT);
-    const HtmlEscape attrEscaper = const HtmlEscape(HtmlEscapeMode.ATTRIBUTE);
+    const HtmlEscape elementEscaper =
+        const HtmlEscape(convert_constant.HtmlEscapeMode.element);
+    const HtmlEscape attrEscaper =
+        const HtmlEscape(convert_constant.HtmlEscapeMode.attribute);
 
     StringBuffer diff = new StringBuffer();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,12 @@ homepage: https://github.com/Workiva/dart_transformer_utils
 dependencies:
   analyzer: ">=0.27.0 <0.33.0"
   barback: ">=0.15.2 <0.16.0"
+  dart2_constant: ^1.0.0
   path: "^1.3.0"
   source_span: "^1.2.0"
 
 dev_dependencies:
-  coverage: ^0.10.0 # 0.11.0+ is Dart 2 only
+  coverage: ">=0.10.0 <0.13.0"
   dart_dev: ^1.9.2
   dart_style: ^1.0.9
   dependency_validator: ^1.1.0


### PR DESCRIPTION
transformer_utils had two instances of Dart 1-only constants from `dart:convert` for `HtmlEscapeMode`.

Use the `dart2_constant` library.