### PR TITLE
AF-1897 Release dart_transformer_utils 0.1.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: transformer_utils
-version: 0.1.4
+version: 0.1.5
 description: Utilities relating to code generation, Dart analyzer, logging, etc. for use in Pub transformers.
 authors:
   - Workiva UI Platform Team <uip@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [Use dart2_constant for HtmlEscapeMode constants](https://github.com/Workiva/dart_transformer_utils/pull/23)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_transformer_utils/compare/0.1.4...Workiva:release_dart_transformer_utils_0_1_5
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_transformer_utils/compare/0.1.4...0.1.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5977371284340736/logs/)