### PR TITLE
CPLAT-5154: Upgrade to analyzer ^0.35.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,18 +8,18 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 homepage: https://github.com/Workiva/dart_transformer_utils
 dependencies:
-  analyzer: ">=0.27.0 <0.33.0"
+  analyzer: ^0.35.0
   build: ^1.0.0
   dart2_constant: ^1.0.1
-  path: "^1.3.0"
-  source_span: "^1.2.0"
+  path: ^1.3.0
+  source_span: ^1.2.0
 
 dev_dependencies:
   coverage: ">=0.10.0 <0.13.0"
-  dart_dev: ">=1.9.2 <3.0.0"
+  dart_dev: ^2.0.0
   dart_style: ^1.0.9
   dependency_validator: ^1.1.0
-  test: ">=0.12.32+1 <2.0.0"
+  test: ^1.5.3
 
 environment:
     sdk: ">=2.0.0 <3.0.0"


### PR DESCRIPTION
# [CPLAT-5154](https://jira.atl.workiva.net/browse/CPLAT-5154)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-5154)

## Changes
Upgrade the `analyzer` dependency to at least `0.35.0`. This will help unblock consumption of the latest `build_*` packages.

## Testing
- [ ] CI passes

## Code Review
@greglittlefield-wf @corwinsheahan-wf 