### PR TITLE
CPLAT-6158: Widen analyzer range to include 0.36.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 homepage: https://github.com/Workiva/dart_transformer_utils
 dependencies:
-  analyzer: ^0.35.0
+  analyzer: '>=0.35.0 <0.37.0'
   build: ^1.0.0
   dart2_constant: ^1.0.1
   path: ^1.3.0


### PR DESCRIPTION
# [CPLAT-6158](https://jira.atl.workiva.net/browse/CPLAT-6158)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-6158)

Some of the latest build_* packages have started requiring at least analyzer 0.36.0. I tried it out locally by upgrading to analyzer 0.36.3, and all tests still pass.

@greglittlefield-wf @corwinsheahan-wf 