### PR TITLE
CPLAT-5162 Release dart_transformer_utils 0.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: transformer_utils
-version: 0.2.1
+version: 0.2.2
 description: Utilities relating to code generation, Dart analyzer, logging, etc. for use in Pub transformers.
 authors:
   - Workiva UI Platform Team <uip@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-6158: Widen analyzer range to include 0.36.x](https://github.com/Workiva/dart_transformer_utils/pull/33)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_transformer_utils/compare/0.2.1...Workiva:release_dart_transformer_utils_0.2.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_transformer_utils/compare/0.2.1...0.2.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5977371284340736/logs/)