### PR TITLE
CPLAT-7442: Run unit tests with dart2js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.dart_tool
+.dart_tool
 /.idea
 /.packages
 /.pub

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ dart:
 script:
   - pub run dart_dev format --check
   - pub run dart_dev analyze
-  - pub run dart_dev test
+  - pub run dart_dev test --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM google/dart:2.1.0
+FROM google/dart:2.5
 
 WORKDIR /build/
 COPY . /build
-RUN timeout 5m pub get && pub run dependency_validator -i coverage,dart_style
+RUN timeout 5m pub get && pub run dependency_validator
 ARG BUILD_ARTIFACTS_AUDIT=/build/pubspec.lock
 FROM scratch

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
 
 dev_dependencies:
   coverage: ">=0.10.0 <0.13.0"
-  dart_dev: ^2.0.0
+  dart_dev: ^2.2.0
   dart_style: ^1.0.9
-  dependency_validator: ^1.1.0
+  dependency_validator: ^1.3.0
   test: ^1.5.3
 
 environment:


### PR DESCRIPTION
## Problem
We are getting ready to ship Dart2 code to production.Since we compile that code with dart2js, it would be great to run unit tests with dart2js as well. This will provide more confidence in the shipped code.

## Solution
- Update deps
- Update `dependency_validator` ignore list
- Run test in release mode

## Testing instructions
- [ ] CI should be sufficient