### PR TITLE
CPLAT-7677 Open analyzer range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
 homepage: https://github.com/Workiva/dart_transformer_utils
 dependencies:
-  analyzer: '>=0.35.0 <0.37.0'
+  analyzer: '>=0.35.0 <0.39.0'
   build: ^1.0.0
   dart2_constant: ^1.0.1
   path: ^1.3.0


### PR DESCRIPTION
### Motivation
Upper bounds of the `analyzer` version need to be increased so that we aren't prevented from pulling newer versions of packages (e.g., `build_web_compilers`) that depend on newer versions of `analyzer`.

Please review @aaronlademann-wf @greglittlefield-wf @kealjones-wk @sydneyjodon-wk 