### PR TITLE
Upgrade dependency_validator

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 dev_dependencies:
   dart_dev: ^3.0.0
   dart_style: ^1.3.3
-  dependency_validator: ^1.4.1
+  dependency_validator: ^2.0.0
   test: ^1.15.7


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades


This batch is to find and open PRs to upgrade dependency_validator to v2.

Additional manual work that might be needed (CP will do):
 [ ] Run dependency_validator to repos that aren't running it,
   but do have the dependency. 
 [ ] Fix CI due to removing an ignore that was actually needed.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_dep_validator`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_dep_validator)