### PR TITLE
FW-171 Only run skynet on releases

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -5,6 +5,12 @@ image: drydock.workiva.net/workiva/skynet-images:3708893 # Uses the image from t
 size: small
 timeout: 600
 
+run:
+  on-pull-request: false
+  on-promotion: true
+  when-modified-file-name-is: 
+    - skynet.yaml
+
 env:
 # encrypted github token used for requests to api.github.com
  - secure: ErVIlZdPg7XHrFRKvtTxawZR38zkJoQ5rb3VrM/pjNVYnUNsNOhIjvOtkJqQDk3g4pgNtPo006anzRpe/aFaHIc1r/k=


### PR DESCRIPTION
## Motivation
Currently the skynet config is running on pull requests as well as releases which is causing us to hit the github api rate limit, we don't really need to have the skynet config running on pull requests because it's just needed for release pipelines. 
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
Add a run config to skynet that limits running to just releases and if there are changes to the skynet.yaml
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
Run skynet only on releases
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->