### PR TITLE
Update to latest image of github ci verifier

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,7 +1,7 @@
 name: verify-github-actions
 description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
 contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
-image: drydock.workiva.net/workiva/skynet-images:3708893 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
+image: drydock.workiva.net/workiva/skynet-images:3728345 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
 size: small
 timeout: 600
 


### PR DESCRIPTION
This updates to the latest image of the github ci verifier and changes on on-pull-request to true

[_Created by Sourcegraph batch change `wesleybalvanz-wf/image-update`._](https://sourcegraph.plat.workiva.net/users/wesleybalvanz-wf/batch-changes/image-update)