### PR TITLE
FEA-895 Widen analyzer range to include v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.17
+
+- Widen analyzer range to include v2
+
 ## 0.2.15
 
 - Widen analyzer range to include v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.41.0 <2.0.0'
+  analyzer: '>=0.41.0 <3.0.0'
   build: '>=1.2.2 <3.0.0'
   path: ^1.6.4
   source_span: ^1.5.5


### PR DESCRIPTION
We can safely widen this package's dependency on analyzer to include v2 without breaking anything. It resolves to v2 on Dart 2.13.4 and all tests and analysis pass.