### PR TITLE
Test Dart 2.18

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ 2.13.4, stable, beta, dev ]
+        sdk: [ 2.13.4, stable, beta ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ 2.13.4, stable, beta ]
+        sdk: [ 2.13.4, 2.18.7, stable, beta ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
 WORKDIR /build/
 COPY . /build
 RUN dart pub get

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7
 WORKDIR /build/
 COPY . /build
 RUN dart pub get


### PR DESCRIPTION
Summary
---
This batch overrides the docker images used to equivalent Dart 2.18 versions.
The goal is to run as many CI runs across the dart ecosystem as possible on 
Dart 2.18 to find and fix errors before releasing a production 2.18 image.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_dart_218`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_dart_218)