### PR TITLE
Release dart_transformer_utils 0.2.18

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: transformer_utils
-version: 0.2.17
+version: 0.2.18
 description: Utilities relating to code generation, Dart analyzer, logging, etc. for use in Dart builders.
 homepage: https://github.com/Workiva/dart_transformer_utils
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Test Dart 2.18](https://github.com/Workiva/dart_transformer_utils/pull/58)
	* [Raise analyzer minimum & unpin meta](https://github.com/Workiva/dart_transformer_utils/pull/59)
	* [Null safety](https://github.com/Workiva/dart_transformer_utils/pull/60)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_transformer_utils/compare/0.2.17...Workiva:release_dart_transformer_utils_0.2.18
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_transformer_utils/compare/0.2.17...0.2.18

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5977371284340736/logs/)