### PR TITLE
Allow analyzer 6

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ 2.18.7, 2.19.6, stable ]
+        sdk: [ 2.19.6, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: dart pub get
       - name: Validate dependencies
-        run: dart run dependency_validator
+        run: dart pub global activate dependency_validator && dart pub global run dependency_validator
       - name: Check formatting
         run: dart format --output=none --set-exit-if-changed .
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Run tests
         run: dart test
       - uses: anchore/sbom-action@v0
+        if: ${{ matrix.sdk == 'stable' }}
         with:
           path: ./
           format: cyclonedx-json

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,12 +7,11 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.0.0
+  analyzer: '>=5.0.0 <7.0.0'
   build:  ^2.0.3
   collection: ^1.15.0
   path: ^1.8.0
   source_span: ^1.8.1
 
 dev_dependencies:
-  dependency_validator: ^3.0.0
   test: ^1.16.0


### PR DESCRIPTION
# Summary

We want to unblock analyzer 6, so open the range to allow it.
While in here, remove the dependency on dependency_validator 3 and install and run it globally instead.

# Testing

 - [ ] CI passes on both Dart 2.19 and Dart 3
 - [ ] On Dart 3, analyzer 6 resolves