### PR TITLE
FED-3969 Allow analyzer 7.x, explicitly support Dart 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,10 @@ description: Utilities relating to code generation, Dart analyzer, logging, etc.
 homepage: https://github.com/Workiva/dart_transformer_utils
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=5.0.0 <7.0.0'
+  analyzer: '>=5.0.0 <8.0.0'
   build:  ^2.0.3
   collection: ^1.15.0
   path: ^1.8.0


### PR DESCRIPTION
## Motivation
The latest [analyzer](https://pub.dev/packages/analyzer) version is 7.x, and this package only allows <7, preventing downstream packages from pulling that in.

## Solution
- Raise upper bound of analyzer
- Update SDK constraint to allow Dart 3, since we already support it and run CI against Dart 3


## Testing
Verify CI passes in Dart 3, and pulls in analyzer 7 (looks like it is [here](https://github.com/Workiva/dart_transformer_utils/actions/runs/15932070625/job/44943359172#step:4:11))