### PR TITLE
RM-302017 Release dart_transformer_utils 0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.2.23
+- Update analyzer dependency to `>=5.0.0 <8.0.0` (allow v7)
+- Raise SDK maximum to officially include Dart 3
+
+## 0.2.22
+- Raise SDK minimum to Dart 2.19
+
+## 0.2.21
+- Update analyzer dependency to `>=5.0.0 <7.0.0` (allow v6)
+
+## 0.2.20
+- Update analyzer dependency to `^5.0.0` (v5 only)
+
+## 0.2.19
+- Update analyzer dependency to `>=2.0.0 <5.0.0` (drop v1, allow v4)
+
+## 0.2.18
+- Update analyzer dependency to `>=1.7.2 <3.0.0` (drop v0.x)
+
 ## 0.2.17
 
 - Widen analyzer range to include v2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: transformer_utils
-version: 0.2.22
+version: 0.2.23
 description: Utilities relating to code generation, Dart analyzer, logging, etc. for use in Dart builders.
 homepage: https://github.com/Workiva/dart_transformer_utils
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-3969 Allow analyzer 7.x, explicitly support Dart 3](https://github.com/Workiva/dart_transformer_utils/pull/77)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_transformer_utils/compare/0.2.22...Workiva:release_dart_transformer_utils_0.2.23
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_transformer_utils/compare/0.2.22...0.2.23

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5977371284340736/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5977371284340736/?repo_name=Workiva%2Fdart_transformer_utils&pull_number=78)